### PR TITLE
convert from fontawesome kit to cdnjs

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="https://kit.fontawesome.com/50f2d62cb4.js" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <title>Kevin DialogueMenu</title>
     <script type="module" crossorigin src="./index.js"></script>
     <link rel="stylesheet" href="./index.css">

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="https://kit.fontawesome.com/50f2d62cb4.js" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <title>Kevin DialogueMenu</title>
   </head>
   <body>


### PR DESCRIPTION
I was having weird issues with icons not loading or displaying as squares.. for basic icons such as `fa-hand` or `fa-clock`. 

I think the kit created by @KevinGirardx only included a subset of icons. 

This makes all icons available using the CDN from CloudFlare.